### PR TITLE
Use yarn to install dependencies if yarn.lock is available

### DIFF
--- a/bin/motley-eslint-init.sh
+++ b/bin/motley-eslint-init.sh
@@ -1,2 +1,12 @@
-PKG=eslint-config-airbnb;
-npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs npm install --save-dev "$PKG@latest"
+PKG=eslint-config-airbnb
+
+# Default to installing using npm
+INSTALL="npm install --save-dev";
+
+# Is this a yarn project, then install using yarn
+if [[ -f $(PWD)/yarn.lock ]]
+then
+  INSTALL="yarn add --dev"
+fi
+
+npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs $INSTALL "$PKG@latest"

--- a/bin/motley-eslint-init.sh
+++ b/bin/motley-eslint-init.sh
@@ -4,7 +4,8 @@ PKG=eslint-config-airbnb
 INSTALL="npm install --save-dev";
 
 # Is this a yarn project, then install using yarn
-if [[ -f $(PWD)/yarn.lock ]]
+YARN_BIN=$(which yarn)
+if [[ -f $(PWD)/yarn.lock -a -x "$YARN_BIN" ]]
 then
   INSTALL="yarn add --dev"
 fi

--- a/bin/motley-eslint-init.sh
+++ b/bin/motley-eslint-init.sh
@@ -3,7 +3,7 @@
 PKG=eslint-config-airbnb
 
 # Default to installing using npm
-INSTALL="npm install --save-dev";
+INSTALL="npm install --save-dev"
 
 # Is this a yarn project and yarn is found in PATH, then install using yarn
 if [[ -f $(PWD)/yarn.lock && -x $(which yarn) ]]
@@ -11,4 +11,4 @@ then
   INSTALL="yarn add --dev"
 fi
 
-npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs "$INSTALL" "$PKG@latest"
+npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs $INSTALL "$PKG@latest"

--- a/bin/motley-eslint-init.sh
+++ b/bin/motley-eslint-init.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 PKG=eslint-config-airbnb
 
 # Default to installing using npm
@@ -9,4 +11,4 @@ then
   INSTALL="yarn add --dev"
 fi
 
-npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs $INSTALL "$PKG@latest"
+npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g' | xargs "$INSTALL" "$PKG@latest"

--- a/bin/motley-eslint-init.sh
+++ b/bin/motley-eslint-init.sh
@@ -3,9 +3,8 @@ PKG=eslint-config-airbnb
 # Default to installing using npm
 INSTALL="npm install --save-dev";
 
-# Is this a yarn project, then install using yarn
-YARN_BIN=$(which yarn)
-if [[ -f $(PWD)/yarn.lock -a -x "$YARN_BIN" ]]
+# Is this a yarn project and yarn is found in PATH, then install using yarn
+if [[ -f $(PWD)/yarn.lock && -x $(which yarn) ]]
 then
   INSTALL="yarn add --dev"
 fi

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Motley Agency's ESLint configuration",
   "main": ".eslintrc.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "./bin/motley-eslint-init.sh"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "bin" : {
     "motley-eslint-init" : "./bin/motley-eslint-init.sh"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": ".eslintrc.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "./bin/motley-eslint-init"
+    "postinstall": "./bin/motley-eslint-init.sh"
   },
   "bin" : {
     "motley-eslint-init" : "./bin/motley-eslint-init.sh"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Motley Agency's ESLint configuration",
   "main": ".eslintrc.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "motley-eslint-init"
   },
   "bin" : {
     "motley-eslint-init" : "./bin/motley-eslint-init.sh"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-motley",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Motley Agency's ESLint configuration",
   "main": ".eslintrc.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": ".eslintrc.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "motley-eslint-init"
+    "postinstall": "./bin/motley-eslint-init"
   },
   "bin" : {
     "motley-eslint-init" : "./bin/motley-eslint-init.sh"


### PR DESCRIPTION
This PR adds a check for yarn.lock in the project dir and installs the dependencies using `yarn` instead of `npm` if available. 