### PR TITLE
Add curly rule disabled by prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,5 +7,6 @@ module.exports = {
   "rules": {
     "no-underscore-dangle": ["error", { "allow": ["__DEV__"] }],
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+    "curly": ["error", "all"],
   }
 }


### PR DESCRIPTION
See https://github.com/prettier/eslint-config-prettier#curly

Prettier doesn't format single line if statements without curly brackets due to ☝️ . IMO curly brackets should always be added, hence the addition. 