### PR TITLE
Add eslint-plugin-react-hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,11 +2,15 @@ module.exports = {
   "extends": [
     "airbnb",
     "prettier",
-    "prettier/react"
+    "prettier/react",
+  ],
+  "plugins": [
+    "react-hooks",
   ],
   "rules": {
     "no-underscore-dangle": ["error", { "allow": ["__DEV__"] }],
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "curly": ["error", "all"],
+    "react-hooks/rules-of-hooks": "error",
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,8 +3,6 @@ module.exports = {
     "airbnb",
     "prettier",
     "prettier/react",
-  ],
-  "plugins": [
     "react-hooks",
   ],
   "rules": {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,8 @@ module.exports = {
     "airbnb",
     "prettier",
     "prettier/react",
+  ],
+  "plugins": [
     "react-hooks",
   ],
   "rules": {

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,6 @@
 # Versions
 
-## 11.0.1
+## 11.1.0
 
 - Added new plugin eslint-plugin-react-hooks
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 # Versions
 
+## 11.0.1
+
+- Added new plugin eslint-plugin-react-hooks
+
 ## 11.0.0
 
 - Upgrade lint-staged to ^8.0.0 to support partially staged files

--- a/package.json
+++ b/package.json
@@ -22,12 +22,13 @@
   ],
   "peerDependencies": {
     "eslint": "^4.19.1 || ^5.3.0",
-    "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-jsx-a11y": "^6.1.1",
-    "eslint-plugin-react": "^7.11.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-prettier": "^3.1.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jsx-a11y": "^6.1.1",
+    "eslint-plugin-react": "^7.11.0",
+    "eslint-plugin-react-hooks": "^0.0.0",
     "husky": "^1.0.1",
     "lint-staged": "^8.0.0",
     "prettier": "^1.14.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-motley",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Motley's JavaScript styleguide using `eslint` and `prettier`",
   "main": ".eslintrc.js",
   "scripts": {


### PR DESCRIPTION
This PR adds linting for new React Hooks feature.

>Don’t call Hooks inside loops, conditions, or nested functions. Instead, always use Hooks at the top level of your React function. By following this rule, you ensure that Hooks are called in the same order each time a component renders. That’s what allows React to correctly preserve the state of Hooks between multiple useState and useEffect calls.