### PR TITLE
Fix missing file extension error

### DIFF
--- a/packages/eslint-config-motley-typescript/.eslintrc.js
+++ b/packages/eslint-config-motley-typescript/.eslintrc.js
@@ -20,8 +20,7 @@ module.exports = {
         "js": "never",
         "jsx": "never",
         "ts": "never",
-        "tsx": "never",
-        "mjs": "never"
+        "tsx": "never"
       }
     ],
   },

--- a/packages/eslint-config-motley-typescript/.eslintrc.js
+++ b/packages/eslint-config-motley-typescript/.eslintrc.js
@@ -12,6 +12,17 @@ module.exports = {
   ],
   rules: {
     'react/jsx-filename-extension': [1, { 'extensions': ['.tsx'] }],
-    'react/prop-types': 0
+    'react/prop-types': 0,
+    'import/extensions': [
+      "error",
+      "ignorePackages",
+      {
+        "js": "never",
+        "jsx": "never",
+        "ts": "never",
+        "tsx": "never",
+        "mjs": "never"
+      }
+    ],
   },
 }


### PR DESCRIPTION
So this PR is related to issue #65 

There are few ways to handle this error:
- Changing `noemit: true` to `noEmit: false` on tsconfig.json and
- And adding following setting to tsconfig `"outDir": "build"`

Or 

- Adding rules defined in this PR to eslintrc.js.

---

I would love the idea that we wouldn't have customize `tsconfig.json` generated by command `npx create-react-app my-app --template typescript` each time. What do you think?