### PR TITLE
Fix Windows compatibility

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,6 @@
 # Versions
 
-## 13.0.1
+## 13.1.0
 
 - Fix Windows compatibility for postinstall scripts.
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 # Versions
 
+## 13.0.1
+
+- Fix Windows compatibility for postinstall scripts.
+
 ## 13.0.0
 
 - Updated dependencies

--- a/packages/eslint-config-motley-typescript/package.json
+++ b/packages/eslint-config-motley-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-motley-typescript",
-  "version": "13.0.0",
+  "version": "13.0.1-alpha",
   "description": "Motley's TypeScript styleguide using `@typescript-eslint` and `prettier`",
   "main": ".eslintrc.js",
   "scripts": {
@@ -31,7 +31,7 @@
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.0",
-    "eslint-config-motley": "13.0.0-alpha",
+    "eslint-config-motley": "13.0.1-alpha",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
     "prettier": "^2.0.5",

--- a/packages/eslint-config-motley-typescript/package.json
+++ b/packages/eslint-config-motley-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-motley-typescript",
-  "version": "13.0.1-alpha",
+  "version": "13.0.3-alpha",
   "description": "Motley's TypeScript styleguide using `@typescript-eslint` and `prettier`",
   "main": ".eslintrc.js",
   "scripts": {
@@ -31,7 +31,7 @@
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.0",
-    "eslint-config-motley": "13.0.1-alpha",
+    "eslint-config-motley": "13.0.3-alpha",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
     "prettier": "^2.0.5",

--- a/packages/eslint-config-motley/lib/postinstall.js
+++ b/packages/eslint-config-motley/lib/postinstall.js
@@ -9,7 +9,7 @@ const readFileAsync = promisify(fs.readFile);
 
 // get the path to the host project.
 const projectPath = path.resolve(process.cwd(), '..', '..');
-const isTypeScript = fs.existsSync(path.resolve(process.env.PWD, '..', 'eslint-config-motley-typescript'));
+const isTypeScript = fs.existsSync(path.resolve(process.cwd(), '..', 'eslint-config-motley-typescript'));
 console.log(`Configuring eslint-config-motley${isTypeScript ? '-typescript': ''}`, projectPath, '\n');
 
 /**

--- a/packages/eslint-config-motley/lib/postinstall.js
+++ b/packages/eslint-config-motley/lib/postinstall.js
@@ -8,8 +8,7 @@ const writeFileAsync = promisify(fs.writeFile);
 const readFileAsync = promisify(fs.readFile);
 
 // get the path to the host project.
-// process.env.PWD doesn't resolve symlinks, e.g. when developing using npm link
-const projectPath = path.resolve(process.env.PWD, '..', '..');
+const projectPath = path.resolve(process.cwd(), '..', '..');
 const isTypeScript = fs.existsSync(path.resolve(process.env.PWD, '..', 'eslint-config-motley-typescript'));
 console.log(`Configuring eslint-config-motley${isTypeScript ? '-typescript': ''}`, projectPath, '\n');
 

--- a/packages/eslint-config-motley/package.json
+++ b/packages/eslint-config-motley/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-motley",
-  "version": "13.0.1-alpha",
+  "version": "13.0.3-alpha",
   "description": "Motley's JavaScript styleguide using `eslint` and `prettier`",
   "main": ".eslintrc.js",
   "scripts": {

--- a/packages/eslint-config-motley/package.json
+++ b/packages/eslint-config-motley/package.json
@@ -1,10 +1,10 @@
 {
   "name": "eslint-config-motley",
-  "version": "13.0.0",
+  "version": "13.0.1-alpha",
   "description": "Motley's JavaScript styleguide using `eslint` and `prettier`",
   "main": ".eslintrc.js",
   "scripts": {
-    "postinstall": "lib/postinstall.js",
+    "postinstall": "node lib/postinstall.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
- Run postinstall commit through node
- Use process.cwd() instead of process.env.PWD
- Use process.cwd() for the TypeScript check too

Tested by installing the TypeScript version successfully on Windows

![image](https://user-images.githubusercontent.com/7641760/106608861-93c60180-656d-11eb-85dd-eaf2a9aa5559.png)
