### PR TITLE
Update eslint-config-prettier to 8.1.0

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 # Versions
 
+## 14.0.0-alpha
+
+- Updated dependencies
+
 ## 13.1.0
 
 - Fix Windows compatibility for postinstall scripts.

--- a/packages/eslint-config-motley-typescript/.eslintrc.js
+++ b/packages/eslint-config-motley-typescript/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: [
     'motley',
     'plugin:@typescript-eslint/recommended',
-    'prettier/@typescript-eslint',
     'plugin:import/typescript',
   ],
   parser: '@typescript-eslint/parser',

--- a/packages/eslint-config-motley-typescript/package.json
+++ b/packages/eslint-config-motley-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-motley-typescript",
-  "version": "13.1.0",
+  "version": "14.0.0-alpha",
   "description": "Motley's TypeScript styleguide using `@typescript-eslint` and `prettier`",
   "main": ".eslintrc.js",
   "scripts": {
@@ -31,7 +31,7 @@
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",
     "eslint-plugin-react-hooks": "^4.1.0",
-    "eslint-config-motley": "13.1.0",
+    "eslint-config-motley": "14.0.0-alpha",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
     "prettier": "^2.0.5",

--- a/packages/eslint-config-motley-typescript/package.json
+++ b/packages/eslint-config-motley-typescript/package.json
@@ -26,7 +26,7 @@
     "eslint": "^7.7.0",
     "eslint-config-airbnb": "18.2.0",
     "eslint-config-airbnb-base": "14.2.0",
-    "eslint-config-prettier": "^6.11.0",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",

--- a/packages/eslint-config-motley/.eslintrc.js
+++ b/packages/eslint-config-motley/.eslintrc.js
@@ -7,7 +7,6 @@ module.exports = {
   extends: [
     'airbnb',
     'prettier',
-    'prettier/react',
   ],
   plugins: [
     'react-hooks',

--- a/packages/eslint-config-motley/package.json
+++ b/packages/eslint-config-motley/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-motley",
-  "version": "13.1.0",
+  "version": "14.0.0-alpha",
   "description": "Motley's JavaScript styleguide using `eslint` and `prettier`",
   "main": ".eslintrc.js",
   "scripts": {

--- a/packages/eslint-config-motley/package.json
+++ b/packages/eslint-config-motley/package.json
@@ -24,7 +24,7 @@
     "eslint": "^7.7.0",
     "eslint-config-airbnb": "18.2.0",
     "eslint-config-airbnb-base": "14.2.0",
-    "eslint-config-prettier": "^6.11.0",
+    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-react": "^7.20.6",


### PR DESCRIPTION
Makes now included prettier/react extension obsolete.