### PR TITLE
Fix TypeScript publish, cannot be run in paraller because of dependency to main package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run test:ci
-  publish-eslint-config-motley:
+  publish-packages:
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
@@ -33,16 +33,6 @@ jobs:
       with:
         token: ${{ secrets.NPM_TOKEN }}
         package: './packages/eslint-config-motley/package.json'
-  publish-eslint-config-typescript:
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js 16.x
-      uses: actions/setup-node@v2
-      with:
-        node-version: 16.x
-        cache: 'npm'
     - uses: JS-DevTools/npm-publish@v1
       with:
         token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes #82 

Signed-off-by: petetnt <pete.a.nykanen@gmail.com>