### PR TITLE
Fix Verdaccio republishing

### DIFF
--- a/.config/verdaccio/config.yaml
+++ b/.config/verdaccio/config.yaml
@@ -12,13 +12,16 @@ uplinks:
     url: https://registry.npmjs.org/
     cache: false
 packages:
+  'eslint-config-motley':
+    access: $all
+    publish: $all
+  'eslint-config-motley-typescript':
+    access: $all
+    publish: $all
   '**':
     access: $all
     publish: $all
     proxy: npmjs
-  '*motley*':
-    access: $all
-    publish: $all
 middlewares:
   audit:
     enabled: true

--- a/scripts/publish-to-verdaccio.sh
+++ b/scripts/publish-to-verdaccio.sh
@@ -16,10 +16,10 @@ cp .npmrc packages/eslint-config-motley-typescript/.npmrc
 
 # Run npm command
 echo "Publishing eslint-config-motley locally"
-cd packages/eslint-config-motley && sh -c "npm --registry $local_registry publish"
+cd packages/eslint-config-motley && sh -c "npm publish --registry $local_registry"
 
 echo "Publishing eslint-config-motley-typescript locally"
-cd ../eslint-config-motley-typescript && sh -c "npm --registry $local_registry publish"
+cd ../eslint-config-motley-typescript && sh -c "npm publish --registry $local_registry"
 cd ../../
 
 cp .npmrc __fixtures__/js/.npmrc


### PR DESCRIPTION
This PR fixes Verdaccio republishing issues (as documented in https://github.com/verdaccio/verdaccio/issues/1203). Basically the tests would fail if the package was already published, making it impossible to do changes that didn't bump package.json versions.

Signed-off-by: petetnt <pete.a.nykanen@gmail.com>