### PR TITLE
fix: remove unncessary git add command #70

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ and the following in your `package.json`:
     }
   },
   "lint-staged": {
-    "*.{js,json,graphql,md,css,scss,less,ts,tsx}": ["prettier --write", "git add"]
+    "*.{js,json,graphql,md,css,scss,less,ts,tsx}": ["prettier --write"]
   }
 }
 ```

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,9 @@
 # Versions
 
+## 15.0.1
+
+- Removed unneccessary `git add`, 
+
 ## 15.0.0
 
 - *BREAKING* only shipping the `typescript` package from now on. If you want to use the old plain JavaScript version, install `eslint-config-motley@14.1.1`

--- a/packages/eslint-config-motley-typescript/lib/postinstall.js
+++ b/packages/eslint-config-motley-typescript/lib/postinstall.js
@@ -42,7 +42,7 @@ const writeToPackageJson = async () => {
 
   // Default configuration for lint-staged
   const lintStaged = {
-    '*.{js,json,graphql,md,css,scss,less,ts,tsx}': ['prettier --write', 'git add'],
+    '*.{js,json,graphql,md,css,scss,less,ts,tsx}': ['prettier --write'],
   };
 
   // Set or update lint-staged configuration


### PR DESCRIPTION
This PR fixes #70 by just removing the unnecessary `git add` command